### PR TITLE
Create usb_interface.md

### DIFF
--- a/Misc/USB/usb_interface.md
+++ b/Misc/USB/usb_interface.md
@@ -1,0 +1,108 @@
+To implement a full USB solution in Verilog, especially when you want to avoid handling all the low-level details of the USB protocol manually, the best approach would be to use **pre-built USB cores** or **IP blocks** that already implement the USB protocol stack. This would allow you to focus on interfacing the USB controller with your application instead of implementing everything from scratch.
+
+I'll guide you through the steps using a **pre-built USB core** for **FPGA** or **ASIC** designs and explain how you can integrate this core into your Verilog code.
+
+### 1. **USB Core Overview**
+
+Many FPGA vendors such as **Xilinx** and **Intel (Altera)** provide **USB cores** that implement the USB protocol stack. These cores handle the complex low-level USB signaling, packet structure, error handling, and device enumeration.
+
+### 2. **Using USB Core in FPGA Design**
+
+Here is the general approach to using a **pre-built USB core** in your Verilog design:
+
+#### Step 1: **Select a USB Core**
+
+- If you're using **Xilinx**, they offer a **USB 2.0/1.1 device controller core** (e.g., **Xilinx USB 2.0 Device Controller IP**).
+- For **Intel (Altera)**, you can use the **USB 2.0 Full-Speed/High-Speed Device IP**.
+- Both companies provide **evaluation versions** or **full versions** of these cores, with documentation and example designs.
+
+These cores typically come with a **wrapper** and **interface signals** that simplify integration into your design.
+
+#### Step 2: **Instantiate the USB Core in Verilog**
+
+Once you have selected the appropriate USB core from your FPGA vendor, the next step is to instantiate it in your design. The core usually provides an interface with several signals such as:
+
+- **Clock (`clk`)**: The clock used for USB communication (often 48 MHz for USB 2.0).
+- **Reset (`rst`)**: A signal to reset the USB controller.
+- **USB Data Lines**: These are differential data lines (D+/D−) or single-ended data lines (depending on the implementation).
+- **Control and Status Signals**: These include signals to indicate when data is ready to be read or when the device is enumerating.
+
+#### Example Verilog Code to Integrate a USB Core
+
+Here's an example of how you might integrate a USB core into a Verilog design, using a simplified version where we focus on sending and receiving data. This assumes you have a USB core instantiated as `usb_device`.
+
+```verilog
+module usb_interface (
+    input clk,                  // System clock
+    input rst,                  // Reset signal
+    input usb_dp,               // USB Data Line (Single-ended or Differential)
+    input usb_dn,               // USB Data Line (Single-ended or Differential)
+    output [7:0] data_out,      // Data to be received from USB
+    output data_ready,          // Data is ready to be processed
+    output data_valid,          // Data is valid for further processing
+    input [7:0] data_in,        // Data to be sent to USB
+    input send_data             // Trigger signal to send data
+);
+
+    // USB core instantiation
+    usb_device_controller #(
+        .USB_VERSION(2)          // Specify USB version (e.g., USB 2.0)
+    ) usb_core (
+        .clk(clk),               // Clock input
+        .rst(rst),               // Reset signal
+        .usb_dp(usb_dp),         // USB Data+ line (single-ended or differential)
+        .usb_dn(usb_dn),         // USB Data- line (single-ended or differential)
+        .data_out(data_out),     // Data received from USB
+        .data_ready(data_ready), // Data received and ready for processing
+        .data_valid(data_valid), // Data valid flag
+        .data_in(data_in),       // Data to be sent to USB
+        .send_data(send_data)    // Trigger to send data to USB
+    );
+
+endmodule
+```
+
+### 3. **Explanation of the Code:**
+
+- **USB Core Interface**: We are assuming that the USB core (`usb_device_controller`) has a straightforward interface where you can connect the USB D+/D− lines to the FPGA's I/O and control data sending/receiving via `data_in` and `data_out`.
+  
+- **Clock and Reset**: The USB core needs a clock (`clk`) and a reset (`rst`) signal. These signals are common in FPGA designs.
+
+- **Data Lines (D+ and D−)**: `usb_dp` and `usb_dn` are the differential data lines used for USB communication. In this example, we simplify it, but you would likely use dedicated I/O pins for these lines in a real FPGA design.
+
+- **Data Transfer**: The core will signal when data is ready (`data_ready`) and when the data is valid (`data_valid`). You can use these signals in your application to handle received data.
+
+- **Sending Data**: When `send_data` is asserted, the core will transmit the `data_in` over the USB bus.
+
+### 4. **USB Enumeration and Application Layer**
+
+The USB core itself manages the low-level protocol, including enumeration, data transfers, and error handling. However, you will also need to manage the **application layer** (e.g., controlling what data gets sent or received based on your specific USB device functionality).
+
+For example, if you're designing a **USB Mass Storage Device** or a **USB HID Device**, you'll need to handle the specific USB class protocols, which might involve:
+
+- **Device Descriptor**: The USB device must present its descriptor to the host during enumeration.
+- **Control Transfers**: Handle control requests such as `SETUP` and `DATA` phases.
+- **Data Transfers**: Handling bulk, interrupt, or isochronous transfers depending on the type of device.
+
+### 5. **Debugging and Simulation**
+
+- **Simulation**: The best way to test the integration of the USB core is by simulating the design first. This will allow you to verify that the USB core communicates correctly and that the application logic (like data sending and receiving) works as expected.
+
+- **Debugging**: Many USB cores come with debug signals that provide insights into the USB enumeration process, data transfers, and error conditions.
+
+### 6. **Final Integration and Deployment**
+
+Once your design is verified and tested in simulation, you can then proceed to integrate it with your system. This typically involves:
+- **FPGA synthesis** to generate the bitstream.
+- **Programming the FPGA** with the generated bitstream.
+- **Connecting to the USB Host** to test communication and functionality.
+
+### 7. **Resources:**
+
+- **Xilinx USB 2.0 Core**: Xilinx provides detailed documentation and IP cores for USB 2.0. You can access these from the Xilinx Vivado IP Catalog.
+- **Intel (Altera) USB IP**: Intel also provides USB cores through the Intel Quartus software. Check their IP catalog for USB cores.
+- **USB Specification**: Refer to the official [USB specification](https://www.usb.org/document-library/usb-20-specification) for details on USB protocols and device classes.
+
+### Conclusion:
+
+Using a **pre-built USB core** is the most efficient and practical way to handle USB communication in Verilog for FPGA designs. This allows you to offload the complexity of the USB protocol and focus on your application. Whether you're working on a USB device (HID, mass storage, etc.) or simply sending/receiving data, these cores abstract most of the low-level communication and provide a higher-level interface that you can easily integrate into your Verilog design.


### PR DESCRIPTION
```markdown
To implement a full USB solution in Verilog, especially when you want to avoid handling all the low-level details of the USB protocol manually, the best approach would be to use **pre-built USB cores** or **IP blocks** that already implement the USB protocol stack. This would allow you to focus on interfacing the USB controller with your application instead of implementing everything from scratch.

I'll guide you through the steps using a **pre-built USB core** for **FPGA** or **ASIC** designs and explain how you can integrate this core into your Verilog code.

### 1. **USB Core Overview**

Many FPGA vendors such as **Xilinx** and **Intel (Altera)** provide **USB cores** that implement the USB protocol stack. These cores handle the complex low-level USB signaling, packet structure, error handling, and device enumeration.

### 2. **Using USB Core in FPGA Design**

Here is the general approach to using a **pre-built USB core** in your Verilog design:

#### Step 1: **Select a USB Core**

- If you're using **Xilinx**, they offer a **USB 2.0/1.1 device controller core** (e.g., **Xilinx USB 2.0 Device Controller IP**).
- For **Intel (Altera)**, you can use the **USB 2.0 Full-Speed/High-Speed Device IP**.
- Both companies provide **evaluation versions** or **full versions** of these cores, with documentation and example designs.

These cores typically come with a **wrapper** and **interface signals** that simplify integration into your design.

#### Step 2: **Instantiate the USB Core in Verilog**

Once you have selected the appropriate USB core from your FPGA vendor, the next step is to instantiate it in your design. The core usually provides an interface with several signals such as:

- **Clock (`clk`)**: The clock used for USB communication (often 48 MHz for USB 2.0).
- **Reset (`rst`)**: A signal to reset the USB controller.
- **USB Data Lines**: These are differential data lines (D+/D−) or single-ended data lines (depending on the implementation).
- **Control and Status Signals**: These include signals to indicate when data is ready to be read or when the device is enumerating.

#### Example Verilog Code to Integrate a USB Core

Here's an example of how you might integrate a USB core into a Verilog design, using a simplified version where we focus on sending and receiving data. This assumes you have a USB core instantiated as `usb_device`.

```verilog
module usb_interface (
    input clk,                  // System clock
    input rst,                  // Reset signal
    input usb_dp,               // USB Data Line (Single-ended or Differential)
    input usb_dn,               // USB Data Line (Single-ended or Differential)
    output [7:0] data_out,      // Data to be received from USB
    output data_ready,          // Data is ready to be processed
    output data_valid,          // Data is valid for further processing
    input [7:0] data_in,        // Data to be sent to USB
    input send_data             // Trigger signal to send data
);

    // USB core instantiation
    usb_device_controller #(
        .USB_VERSION(2)          // Specify USB version (e.g., USB 2.0)
    ) usb_core (
        .clk(clk),               // Clock input
        .rst(rst),               // Reset signal
        .usb_dp(usb_dp),         // USB Data+ line (single-ended or differential)
        .usb_dn(usb_dn),         // USB Data- line (single-ended or differential)
        .data_out(data_out),     // Data received from USB
        .data_ready(data_ready), // Data received and ready for processing
        .data_valid(data_valid), // Data valid flag
        .data_in(data_in),       // Data to be sent to USB
        .send_data(send_data)    // Trigger to send data to USB
    );

endmodule
```

### 3. **Explanation of the Code:**

- **USB Core Interface**: We are assuming that the USB core (`usb_device_controller`) has a straightforward interface where you can connect the USB D+/D− lines to the FPGA's I/O and control data sending/receiving via `data_in` and `data_out`.
  
- **Clock and Reset**: The USB core needs a clock (`clk`) and a reset (`rst`) signal. These signals are common in FPGA designs.

- **Data Lines (D+ and D−)**: `usb_dp` and `usb_dn` are the differential data lines used for USB communication. In this example, we simplify it, but you would likely use dedicated I/O pins for these lines in a real FPGA design.

- **Data Transfer**: The core will signal when data is ready (`data_ready`) and when the data is valid (`data_valid`). You can use these signals in your application to handle received data.

- **Sending Data**: When `send_data` is asserted, the core will transmit the `data_in` over the USB bus.

### 4. **USB Enumeration and Application Layer**

The USB core itself manages the low-level protocol, including enumeration, data transfers, and error handling. However, you will also need to manage the **application layer** (e.g., controlling what data gets sent or received based on your specific USB device functionality).

For example, if you're designing a **USB Mass Storage Device** or a **USB HID Device**, you'll need to handle the specific USB class protocols, which might involve:

- **Device Descriptor**: The USB device must present its descriptor to the host during enumeration.
- **Control Transfers**: Handle control requests such as `SETUP` and `DATA` phases.
- **Data Transfers**: Handling bulk, interrupt, or isochronous transfers depending on the type of device.

### 5. **Debugging and Simulation**

- **Simulation**: The best way to test the integration of the USB core is by simulating the design first. This will allow you to verify that the USB core communicates correctly and that the application logic (like data sending and receiving) works as expected.

- **Debugging**: Many USB cores come with debug signals that provide insights into the USB enumeration process, data transfers, and error conditions.

### 6. **Final Integration and Deployment**

Once your design is verified and tested in simulation, you can then proceed to integrate it with your system. This typically involves:
- **FPGA synthesis** to generate the bitstream.
- **Programming the FPGA** with the generated bitstream.
- **Connecting to the USB Host** to test communication and functionality.

### 7. **Resources:**

- **Xilinx USB 2.0 Core**: Xilinx provides detailed documentation and IP cores for USB 2.0. You can access these from the Xilinx Vivado IP Catalog.
- **Intel (Altera) USB IP**: Intel also provides USB cores through the Intel Quartus software. Check their IP catalog for USB cores.
- **USB Specification**: Refer to the official [USB specification](https://www.usb.org/document-library/usb-20-specification) for details on USB protocols and device classes.

### Conclusion:

Using a **pre-built USB core** is the most efficient and practical way to handle USB communication in Verilog for FPGA designs. This allows you to offload the complexity of the USB protocol and focus on your application. Whether you're working on a USB device (HID, mass storage, etc.) or simply sending/receiving data, these cores abstract most of the low-level communication and provide a higher-level interface that you can easily integrate into your Verilog design.
```