### PR TITLE
Add Verilog Module Synthesis Workflow

### DIFF
--- a/.github/workflows/synthesis.yml
+++ b/.github/workflows/synthesis.yml
@@ -1,0 +1,41 @@
+name: Synthesis
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  synthesize:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Install Yosys
+      run: sudo apt-get install -y yosys
+
+    - name: Run synthesis
+      run: |
+        yosys -p "synth -top top_module" 1.Getting\ Started/step_one.v
+        yosys -p "synth -top top_module" 1.Getting\ Started/zero.v
+        yosys -p "synth -top ALU" Misc/32-bit-CPU/arithmetic_logic_unit.v
+        yosys -p "synth -top ControlUnit" Misc/32-bit-CPU/control_unit.v
+        yosys -p "synth -top CPU" Misc/32-bit-CPU/datapath.v
+        yosys -p "synth -top RegisterFile" Misc/32-bit-CPU/register_file.v
+        yosys -p "synth -top sha256_core" Misc/BruteForce/sha256.v
+        yosys -p "synth -top elevator_1floor" Misc/Elevator/1-Floor\ Elevator.v
+        yosys -p "synth -top elevator_2floor" Misc/Elevator/2-Floor\ Eleavtor.v
+        yosys -p "synth -top elevator_1floor_lock" Misc/Elevator/elevator_1floor_lock.v
+        yosys -p "synth -top elevator_2floor_lock" Misc/Elevator/elevator_2floor_lock.v
+        yosys -p "synth -top elevator_3floor" Misc/Elevator/elevator_3floor.v
+        yosys -p "synth -top elevator_3floor" Misc/Elevator/elevator_3floor_lock.v
+        yosys -p "synth -top usb_interface" Misc/USB/usb_interface.v
+        yosys -p "synth -top readonly_device" readonly_device.v
+        yosys -p "synth -top rom_memory" rom_memory.v
+        yosys -p "synth -top write_only_device" write_only_device.v
+        yosys -p "synth -top implication_gate" Test/testbench.v

--- a/README.md
+++ b/README.md
@@ -114,3 +114,11 @@ The "Verilog Language" section covers various aspects of Verilog, including basi
 # Circuits
 
 The "Circuits" section includes examples of combinational and sequential logic circuits implemented in Verilog. It covers topics such as arithmetic circuits, basic gates, Karnaugh maps, multiplexers, counters, finite state machines, and shift registers. Each example demonstrates the functionality of a specific type of circuit and provides a brief description of its purpose.
+
+# GitHub Actions Workflow
+
+This repository includes a GitHub Actions workflow to ensure that all Verilog modules are synthesizable. The workflow is defined in the `.github/workflows/synthesis.yml` file.
+
+## Viewing Synthesis Results
+
+To view the synthesis results, navigate to the "Actions" tab in your GitHub repository. You will see a list of workflow runs. Click on a specific run to view the details, including the synthesis results and any errors or warnings that were encountered.


### PR DESCRIPTION
Add a GitHub Actions workflow to ensure Verilog modules are synthesizable.

* **README.md**
  - Add a section explaining the new GitHub Actions workflow.
  - Provide instructions on how to view the synthesis results in the GitHub Actions tab.

* **.github/workflows/synthesis.yml**
  - Create a new GitHub Actions workflow file named `synthesis.yml`.
  - Define the workflow to trigger on push and pull request events.
  - Set up a job named `synthesize` that runs on `ubuntu-latest`.
  - Add steps to check out the repository and install Yosys.
  - Add a step to run the synthesis tool on various Verilog files and check for errors.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ewdlop/Verilog-Notes/pull/22?shareId=5850885a-1485-425c-96e8-850df7359c37).